### PR TITLE
Considering additionalProperties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 coverage/
 node_modules/
+.idea

--- a/src/validate.js
+++ b/src/validate.js
@@ -4,7 +4,7 @@ const Joi = require("@hapi/joi");
 const validate = async (parsed, passedRules) => {
   const errors = [];
   const rules = Object.assign({ type: "object" }, passedRules);
-  const schema = Enjoi.schema(rules).unknown();
+  const schema = Enjoi.schema(rules).unknown(rules.additionalProperties);
 
   parsed.data.forEach((row, i) => {
     Joi.validate(row, schema, { abortEarly: false }, err => {

--- a/test/readCsv.test.js
+++ b/test/readCsv.test.js
@@ -13,6 +13,6 @@ test("Throws an error on non-existent file", async () => {
 
 test("Throws an error when passed a non-string file path", async () => {
   await expect(readCsv(false)).rejects.toThrow(
-    'The "path" argument must be one of type string, Buffer, or URL. Received type boolean'
+    'The "path" argument must be of type string or an instance of Buffer or URL. Received type boolean (false)'
   );
 });

--- a/test/readRules.test.js
+++ b/test/readRules.test.js
@@ -13,6 +13,6 @@ test("Throws an error on non-existent rules file", async () => {
 
 test("Throws an error when passed a non-string file path", async () => {
   await expect(readRules(false)).rejects.toThrow(
-    'The "path" argument must be one of type string, Buffer, or URL. Received type boolean'
+    'The "path" argument must be of type string or an instance of Buffer or URL. Received type boolean (false)'
   );
 });

--- a/test/validate.test.js
+++ b/test/validate.test.js
@@ -69,3 +69,24 @@ test("Throws an error when multiple checks fail on the same row", async () => {
     'Row 2: "age" must be larger than or equal to 0\nRow 2: "salary" must be a number'
   );
 });
+
+test("Throws an error extra rows are specified an additionalProperties is set to false", async () => {
+  const parsed = await parseCsv("name,age,salary\nJohn,10,5000");
+
+  const rules = {
+    properties: {
+      age: {
+        type: "number",
+        minimum: 0
+      },
+      salary: {
+        type: "number"
+      }
+    },
+    additionalProperties: false
+  };
+
+  await expect(validate(parsed, rules)).rejects.toThrow(
+    'Row 2: "name" is not allowed'
+  );
+});


### PR DESCRIPTION
I encountered an issue during my use of csval that if I used the additionalProperties keyword in jsonSchema it was not being respected.  I believe I've fixed it in this PR and I updated the tests to match the new expected errors.  I also added a test to prove functionality.